### PR TITLE
Update services keys in Transmission #24686

### DIFF
--- a/packages/notify_toast.yaml
+++ b/packages/notify_toast.yaml
@@ -176,7 +176,7 @@ automation:
     action:
       - service: transmission.stop_torrent
         data:
-          name: Transmission
+          entry_id: Transmission
           id: >
             {{ trigger.event.data.id }}
       - delay:
@@ -188,6 +188,6 @@ automation:
           minutes: 10
       - service: transmission.remove_torrent
         data:
-          name: Transmission
+          entry_id: Transmission
           id: >
             {{ trigger.event.data.id }}


### PR DESCRIPTION
If you update to HA 2022.12.0 we need to change name to entry_id as explained here:
PR: https://github.com/home-assistant/home-assistant.io/pull/24686
as explained in the documentation here : https://github.com/home-assistant/home-assistant.io/pull/24686/files