### PR TITLE
Update person_persistence.yaml mqtt publish

### DIFF
--- a/packages/person_persistence.yaml
+++ b/packages/person_persistence.yaml
@@ -50,8 +50,8 @@ automation:
     action:
       service: mqtt.publish
       data:
-        topic_template: >
+        topic: >
           homeassistant/persistence/{{ trigger.to_state.name | lower }}
-        payload_template: >
+        payload: >
           {{ now() }}
         retain: true


### PR DESCRIPTION
Due to changes in HA, the publish options used are begin deprecated. See: https://github.com/home-assistant/core/pull/122098